### PR TITLE
Treat MedMNIST subsets as datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pip install -r requirements.txt --user
 # Set a symbolic link to ImageNet validation data (used only to evaluate model) 
 mkdir data
 ln -s /path/to/imagenet/ data/
+# MedMNIST dataset will be downloaded automatically when selected
 ```
 
 The folder structures should be the same as following
@@ -55,11 +56,18 @@ export CUDA_VISIBLE_DEVICES=0
 python uniform_test.py [--dataset] [--model] [--batch_size] [--test_batch_size]
 
 optional arguments:
---dataset                   type of dataset (default: imagenet)
+--dataset                   type of dataset (imagenet/cifar10/pathmnist/dermamnist/octmnist/pneumoniamnist/retinamnist/breastmnist/bloodmnist/tissuemnist/organamnist/organcmnist/organsmnist, default: imagenet)
 --model                     model to be quantized (default: resnet18)
 --batch-size                batch size of distilled data (default: 64)
 --test-batch-size           batch size of test data (default: 512)
+--pretrained               path to pretrained weights
+--weight_bit               bitwidth for weights (default: 8)
+--act_bit                  bitwidth for activations (default: 8)
 ```
+
+The script prints progress to the console and also writes the same information
+to a log file under `log/<dataset>_<model>_<weight_bit>w_<act_bit>a/` with a
+timestamped filename.
 
 
 

--- a/classification/README.md
+++ b/classification/README.md
@@ -11,9 +11,10 @@ This repository contains the PyTorch implementation for the **CVPR 2020** paper 
 ```bash
 # Code is based on PyTorch 1.2 (Cuda10). Other dependancies could be installed as follows: 
 pip install -r requirements.txt --user
-# Set a symbolic link to ImageNet validation data (used only to evaluate model) 
+# Set a symbolic link to ImageNet validation data (used only to evaluate model)
 mkdir data
 ln -s /path/to/imagenet/ data/
+# MedMNIST dataset will be downloaded automatically when selected
 ```
 
 The folder structures should be the same as following
@@ -51,11 +52,17 @@ export CUDA_VISIBLE_DEVICES=0
 python uniform_test.py [--dataset] [--model] [--batch_size] [--test_batch_size]
 
 optional arguments:
---dataset                   type of dataset (default: imagenet)
+--dataset                   type of dataset (imagenet/cifar10/pathmnist/dermamnist/octmnist/pneumoniamnist/retinamnist/breastmnist/bloodmnist/tissuemnist/organamnist/organcmnist/organsmnist, default: imagenet)
 --model                     model to be quantized (default: resnet18)
 --batch-size                batch size of distilled data (default: 64)
 --test-batch-size           batch size of test data (default: 512)
+--pretrained               path to pretrained weights
+--weight_bit               bitwidth for weights (default: 8)
+--act_bit                  bitwidth for activations (default: 8)
 ```
+
+Logs are saved under `log/<dataset>_<model>_<weight_bit>w_<act_bit>a/` with a
+timestamped filename.
 
 
 

--- a/classification/classification/README.md
+++ b/classification/classification/README.md
@@ -14,6 +14,7 @@ pip install -r requirements.txt --user
 # Set a symbolic link to ImageNet validation data (used only to evaluate model) 
 mkdir data
 ln -s /path/to/imagenet/ data/
+# MedMNIST dataset will be downloaded automatically when selected
 ```
 
 The folder structures should be the same as following
@@ -51,11 +52,17 @@ export CUDA_VISIBLE_DEVICES=0
 python uniform_test.py [--dataset] [--model] [--batch_size] [--test_batch_size]
 
 optional arguments:
---dataset                   type of dataset (default: imagenet)
+--dataset                   type of dataset (imagenet/cifar10/pathmnist/dermamnist/octmnist/pneumoniamnist/retinamnist/breastmnist/bloodmnist/tissuemnist/organamnist/organcmnist/organsmnist, default: imagenet)
 --model                     model to be quantized (default: resnet18)
 --batch-size                batch size of distilled data (default: 64)
 --test-batch-size           batch size of test data (default: 512)
+--pretrained               path to pretrained weights
+--weight_bit               bitwidth for weights (default: 8)
+--act_bit                  bitwidth for activations (default: 8)
 ```
+
+Logs are saved under `log/<dataset>_<model>_<weight_bit>w_<act_bit>a/` with a
+timestamped filename.
 
 
 

--- a/classification/classification/requirements.txt
+++ b/classification/classification/requirements.txt
@@ -1,3 +1,4 @@
 pytorchcv==0.0.51
 progressbar>=1.5
 progress
+medmnist>=2.0.1

--- a/classification/distill_data.py
+++ b/classification/distill_data.py
@@ -63,8 +63,8 @@ def getDistilData(teacher_model,
 	dataset: the name of the dataset
 	batch_size: the batch size of generated distilled data
 	num_batch: the number of batch of generated distilled data
-	for_inception: whether the data is for Inception because inception has input size 299 rather than 224
-	"""
+        for_inception: whether the data is for Inception because inception has input size 299 rather than 224
+        """
 
     # initialize distilled data with random noise according to the dataset
     dataloader = getRandomData(dataset=dataset,

--- a/classification/reconstruct_data.py
+++ b/classification/reconstruct_data.py
@@ -63,8 +63,8 @@ def getReconData(teacher_model,
 	dataset: the name of dataset
 	batch_size: the batch size of generated distilled data
 	num_batch: the number of batch of generated distilled data
-	for_inception: whether the data is for Inception because inception has input size 299 rather than 224
-	"""
+        for_inception: whether the data is for Inception because inception has input size 299 rather than 224
+        """
 
     # initialize distilled data with random noise according to the dataset
     dataloader = getRandomData(dataset=dataset,

--- a/classification/requirements.txt
+++ b/classification/requirements.txt
@@ -1,3 +1,4 @@
 pytorchcv==0.0.51
 progressbar>=1.5
 progress
+medmnist>=2.0.1

--- a/classification/uniform_test.py
+++ b/classification/uniform_test.py
@@ -22,9 +22,14 @@ import argparse
 import torch
 import numpy as np
 import torch.nn as nn
+import logging
+import os
+from datetime import datetime
 from pytorchcv.model_provider import get_model as ptcv_get_model
 from utils import *
 from distill_data import *
+
+MEDMNIST_CLASSES = CLASSIFICATION_DATASETS
 
 
 # model settings
@@ -34,7 +39,7 @@ def arg_parse():
     parser.add_argument('--dataset',
                         type=str,
                         default='imagenet',
-                        choices=['imagenet', 'cifar10'],
+                        choices=['imagenet', 'cifar10'] + list(MEDMNIST_CLASSES.keys()),
                         help='type of dataset')
     parser.add_argument('--model',
                         type=str,
@@ -53,23 +58,71 @@ def arg_parse():
                         type=int,
                         default=128,
                         help='batch size of test data')
+    parser.add_argument('--pretrained',
+                        type=str,
+                        default=None,
+                        help='path to pretrained weights')
+    parser.add_argument('--weight_bit',
+                        type=int,
+                        default=8,
+                        help='bitwidth for weights')
+    parser.add_argument('--act_bit',
+                        type=int,
+                        default=8,
+                        help='bitwidth for activations')
     args = parser.parse_args()
     return args
 
 
+def create_logger(args):
+    log_dir = os.path.join(
+        'log',
+        f"{args.dataset}_{args.model}_{args.weight_bit}w_{args.act_bit}a",
+    )
+    os.makedirs(log_dir, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    log_file = os.path.join(log_dir, f'{timestamp}.log')
+
+    logger = logging.getLogger('zeroq')
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s - %(message)s')
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
 if __name__ == '__main__':
     args = arg_parse()
+    logger = create_logger(args)
     torch.backends.cudnn.deterministic = False
     torch.backends.cudnn.benchmark = True
 
     # Load pretrained model
-    model = ptcv_get_model(args.model, pretrained=True)
-    print('****** Full precision model loaded ******')
+    if args.dataset in MEDMNIST_CLASSES:
+        num_classes = MEDMNIST_CLASSES.get(args.dataset, 2)
+        model = ptcv_get_model(
+            args.model, pretrained=False, num_classes=num_classes)
+        if args.pretrained is not None:
+            model.load_state_dict(torch.load(args.pretrained))
+    else:
+        if args.pretrained is not None:
+            model = ptcv_get_model(args.model, pretrained=False)
+            model.load_state_dict(torch.load(args.pretrained))
+        else:
+            model = ptcv_get_model(args.model, pretrained=True)
+    logger.info('****** Full precision model loaded ******')
 
     # Load validation data
     test_loader = getTestData(args.dataset,
                               batch_size=args.test_batch_size,
-                              path='./data/imagenet/',
+                              path='./data/medmnist/' if args.dataset in MEDMNIST_CLASSES else './data/imagenet/',
                               for_inception=args.model.startswith('inception'))
     # Generate distilled data
     dataloader = getDistilData(
@@ -77,21 +130,22 @@ if __name__ == '__main__':
         args.dataset,
         batch_size=args.batch_size,
         for_inception=args.model.startswith('inception'))
-    print('****** Data loaded ******')
+    logger.info('****** Data loaded ******')
 
-    # Quantize single-precision model to 8-bit model
-    quantized_model = quantize_model(model)
+    # Quantize single-precision model
+    quantized_model = quantize_model(
+        model, weight_bit=args.weight_bit, act_bit=args.act_bit)
     # Freeze BatchNorm statistics
     quantized_model.eval()
     quantized_model = quantized_model.cuda()
 
     # Update activation range according to distilled data
     update(quantized_model, dataloader)
-    print('****** Zero Shot Quantization Finished ******')
+    logger.info('****** Zero Shot Quantization Finished ******')
 
     # Freeze activation range during test
     freeze_model(quantized_model)
     quantized_model = nn.DataParallel(quantized_model).cuda()
 
     # Test the final quantized model
-    test(quantized_model, test_loader)
+    test(quantized_model, test_loader, logger)

--- a/classification/utils/quantize_model.py
+++ b/classification/utils/quantize_model.py
@@ -26,7 +26,7 @@ from pytorchcv.models.common import ConvBlock
 from pytorchcv.models.shufflenetv2 import ShuffleUnit, ShuffleInitBlock
 
 
-def quantize_model(model):
+def quantize_model(model, weight_bit=8, act_bit=8):
     """
     Recursively quantize a pretrained single-precision model to int8 quantized model
     model: pretrained single-precision model
@@ -34,30 +34,30 @@ def quantize_model(model):
 
     # quantize convolutional and linear layers to 8-bit
     if type(model) == nn.Conv2d:
-        quant_mod = Quant_Conv2d(weight_bit=8)
+        quant_mod = Quant_Conv2d(weight_bit=weight_bit)
         quant_mod.set_param(model)
         return quant_mod
     elif type(model) == nn.Linear:
-        quant_mod = Quant_Linear(weight_bit=8)
+        quant_mod = Quant_Linear(weight_bit=weight_bit)
         quant_mod.set_param(model)
         return quant_mod
 
     # quantize all the activation to 8-bit
     elif type(model) == nn.ReLU or type(model) == nn.ReLU6:
-        return nn.Sequential(*[model, QuantAct(activation_bit=8)])
+        return nn.Sequential(*[model, QuantAct(activation_bit=act_bit)])
 
     # recursively use the quantized module to replace the single-precision module
     elif type(model) == nn.Sequential:
         mods = []
         for n, m in model.named_children():
-            mods.append(quantize_model(m))
+            mods.append(quantize_model(m, weight_bit, act_bit))
         return nn.Sequential(*mods)
     else:
         q_model = copy.deepcopy(model)
         for attr in dir(model):
             mod = getattr(model, attr)
             if isinstance(mod, nn.Module) and 'norm' not in attr:
-                setattr(q_model, attr, quantize_model(mod))
+                setattr(q_model, attr, quantize_model(mod, weight_bit, act_bit))
         return q_model
 
 

--- a/classification/utils/train_utils.py
+++ b/classification/utils/train_utils.py
@@ -24,7 +24,7 @@ import torch.nn as nn
 from progress.bar import Bar
 
 
-def test(model, test_loader):
+def test(model, test_loader, logger=None):
     """
     test a model on a given dataset
     """
@@ -42,7 +42,11 @@ def test(model, test_loader):
 
             bar.suffix = f'({batch_idx + 1}/{len(test_loader)}) | ETA: {bar.eta_td} | top1: {acc}'
             bar.next()
-    print('\nFinal acc: %.2f%% (%d/%d)' % (100. * acc, correct, total))
+    msg = '\nFinal acc: %.2f%% (%d/%d)' % (100. * acc, correct, total)
+    if logger is not None:
+        logger.info(msg)
+    else:
+        print(msg)
     bar.finish()
     model.train()
     return acc

--- a/detection/tools/utils/quantize_model.py
+++ b/detection/tools/utils/quantize_model.py
@@ -26,7 +26,7 @@ from pytorchcv.models.common import ConvBlock
 from pytorchcv.models.shufflenetv2 import ShuffleUnit, ShuffleInitBlock
 
 
-def quantize_model(model):
+def quantize_model(model, weight_bit=8, act_bit=8):
     """
     Recursively quantize a pretrained single-precision model to int8 quantized model
     model: pretrained single-precision model
@@ -34,30 +34,30 @@ def quantize_model(model):
 
     # quantize convolutional and linear layers to 8-bit
     if type(model) == nn.Conv2d:
-        quant_mod = Quant_Conv2d(weight_bit=8)
+        quant_mod = Quant_Conv2d(weight_bit=weight_bit)
         quant_mod.set_param(model)
         return quant_mod
     elif type(model) == nn.Linear:
-        quant_mod = Quant_Linear(weight_bit=8)
+        quant_mod = Quant_Linear(weight_bit=weight_bit)
         quant_mod.set_param(model)
         return quant_mod
 
     # quantize all the activation to 8-bit
     elif type(model) == nn.ReLU or type(model) == nn.ReLU6:
-        return nn.Sequential(*[model, QuantAct(activation_bit=8)])
+        return nn.Sequential(*[model, QuantAct(activation_bit=act_bit)])
 
     # recursively use the quantized module to replace the single-precision module
     elif type(model) == nn.Sequential:
         mods = []
         for n, m in model.named_children():
-            mods.append(quantize_model(m))
+            mods.append(quantize_model(m, weight_bit, act_bit))
         return nn.Sequential(*mods)
     else:
         q_model = copy.deepcopy(model)
         for attr in dir(model):
             mod = getattr(model, attr)
             if isinstance(mod, nn.Module) and 'norm' not in attr:
-                setattr(q_model, attr, quantize_model(mod))
+                setattr(q_model, attr, quantize_model(mod, weight_bit, act_bit))
         return q_model
 
 


### PR DESCRIPTION
## Summary
- accept MedMNIST subset names directly for `--dataset`
- drop `--medmnist_dataset` CLI argument
- update data loaders to recognize MedMNIST subsets
- document new dataset options in READMEs

## Testing
- `python -m py_compile classification/utils/train_utils.py classification/uniform_test.py classification/classification/uniform_test.py classification/utils/data_utils.py classification/distill_data.py classification/reconstruct_data.py classification/utils/quantize_model.py detection/tools/utils/quantize_model.py`

------
https://chatgpt.com/codex/tasks/task_e_686f289de430832a88b0f3459d24230f