### PR TITLE
Add dataset path option and update MedMNIST scripts

### DIFF
--- a/classification/classification/run.sh
+++ b/classification/classification/run.sh
@@ -1,9 +1,13 @@
-for MODEL in resnet18 resnet50 inceptionv3 mobilenetv2_w1 shufflenet_g1_w1 sqnxt23_w2
+for DATASET in dermamnist tissuemnist
 do
-	echo Testing $MODEL ...
-	python uniform_test.py 		\
-		--dataset=imagenet 		\
-		--model=$MODEL 			\
-		--batch_size=64 		\
-		--test_batch_size=512
+    for BIT in 2 3 4
+    do
+        echo "Testing $DATASET with W${BIT}A${BIT} ..."
+        python uniform_test.py \
+            --dataset=$DATASET \
+            --weight_bit=$BIT \
+            --act_bit=$BIT \
+            --batch_size=64 \
+            --test_batch_size=512
+    done
 done

--- a/classification/classification/uniform_test.py
+++ b/classification/classification/uniform_test.py
@@ -80,6 +80,10 @@ def arg_parse():
                         type=str,
                         default=None,
                         help='load a quantized model')
+    parser.add_argument('--data_path',
+                        type=str,
+                        default=None,
+                        help='path to dataset')
     args = parser.parse_args()
     return args
 
@@ -157,9 +161,11 @@ if __name__ == '__main__':
         logger.info('****** Zero Shot Quantization Finished ******')
 
     # Load validation data
+    default_path = './data/medmnist/' if args.dataset in MEDMNIST_CLASSES else './data/imagenet/'
+    data_path = args.data_path if args.data_path is not None else default_path
     test_loader = getTestData(args.dataset,
                               batch_size=args.test_batch_size,
-                              path='./data/medmnist/' if args.dataset in MEDMNIST_CLASSES else './data/imagenet/',
+                              path=data_path,
                               for_inception=args.model.startswith('inception'))
 
     # Freeze activation range during test

--- a/classification/run.sh
+++ b/classification/run.sh
@@ -1,9 +1,13 @@
-for MODEL in resnet18 resnet50 inceptionv3 mobilenetv2_w1 shufflenet_g1_w1 sqnxt23_w2
+for DATASET in dermamnist tissuemnist
 do
-	echo Testing $MODEL ...
-	python uniform_test.py 		\
-		--dataset=imagenet 		\
-		--model=$MODEL 			\
-		--batch_size=64 		\
-		--test_batch_size=512
+    for BIT in 2 3 4
+    do
+        echo "Testing $DATASET with W${BIT}A${BIT} ..."
+        python uniform_test.py \
+            --dataset=$DATASET \
+            --weight_bit=$BIT \
+            --act_bit=$BIT \
+            --batch_size=64 \
+            --test_batch_size=512
+    done
 done

--- a/classification/uniform_test.py
+++ b/classification/uniform_test.py
@@ -70,6 +70,10 @@ def arg_parse():
                         type=int,
                         default=8,
                         help='bitwidth for activations')
+    parser.add_argument('--data_path',
+                        type=str,
+                        default=None,
+                        help='path to dataset')
     args = parser.parse_args()
     return args
 
@@ -120,9 +124,11 @@ if __name__ == '__main__':
     logger.info('****** Full precision model loaded ******')
 
     # Load validation data
+    default_path = './data/medmnist/' if args.dataset in MEDMNIST_CLASSES else './data/imagenet/'
+    data_path = args.data_path if args.data_path is not None else default_path
     test_loader = getTestData(args.dataset,
                               batch_size=args.test_batch_size,
-                              path='./data/medmnist/' if args.dataset in MEDMNIST_CLASSES else './data/imagenet/',
+                              path=data_path,
                               for_inception=args.model.startswith('inception'))
     # Generate distilled data
     dataloader = getDistilData(


### PR DESCRIPTION
## Summary
- enable specifying dataset location via `--data_path`
- update default dataset loading logic with new arg
- adjust run scripts to run experiments for dermamnist and tissuemnist across bit widths 2, 3 and 4

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6870968815b0832a8a7da3776f521954